### PR TITLE
Update v3.28.0

### DIFF
--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Todo",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
+    "runtime-version": "3.28",
     "branch": "stable",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-todo",
@@ -117,7 +117,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-todo/3.26/gnome-todo-3.26.2.tar.xz",
+                    "url": "https://download.gnome.org/sources/gnome-todo/3.28/gnome-todo-3.28.0.tar.xz",
                     "sha256": "c9b90048b62b4e6fe7cd7e9675be9a838d65e297584c308bacb25f1478e8dd80"
                 }
             ]


### PR DESCRIPTION
==============
Version 3.28.0
==============

Project:
	* Minor UI fixups and polishing
	* Many translation updates

Todoist:
	* Todoist commands are now compressed, which allows up to 5.000 commands per minute. It
	  is very unlikely that users will ever reach Todoist limits now
	* Tasks appear in GNOME To Do exactly how they appear in Todoist now

EDS:
	* GNOME To Do now reacts to changes made by other applications such as Evolution
	* The backend received more stability and fixes

Todo.txt:
	* Hide internal data with 'h:1' (Kainaat Singh)
	* Minor fixups