### PR TITLE
Remove manifest-wide build-options

### DIFF
--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -22,13 +22,6 @@
         "--talk-name=ca.desrt.dconf",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g",
-        "env" : {
-            "V" : "1"
-        }
-    },
     "cleanup" : [
         "/include",
         "/lib/pkgconfig",


### PR DESCRIPTION
These are handled by the runtime as of fd.o 18.08/GNOME 3.30.