### PR TITLE
Update Endeavour runtime to 47

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,117 @@
+From cf38689e583ca31edd5db3bcca4fb755cc3ac653 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Mon, 29 Jul 2024 18:00:56 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+- Update homepage URL
+- Add vcs-browser URL to show the source code repository
+- Add translate URL to show the translation repository
+- Fix markup errors
+---
+ data/appdata/org.gnome.Todo.appdata.xml.in.in | 44 ++++++++------------------------------------
+ 1 file changed, 8 insertions(+), 36 deletions(-)
+
+diff --git a/data/appdata/org.gnome.Todo.appdata.xml.in.in b/data/appdata/org.gnome.Todo.appdata.xml.in.in
+index 07a4290..12d0dd3 100644
+--- a/data/appdata/org.gnome.Todo.appdata.xml.in.in
++++ b/data/appdata/org.gnome.Todo.appdata.xml.in.in
+@@ -1,5 +1,5 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<component type="desktop">
++<component type="desktop-application">
+   <id>@appid@</id>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-3.0+</project_license>
+@@ -13,12 +13,14 @@
+     </p>
+   </description>
+ 
+-  <url type="homepage">https://wiki.gnome.org/Apps/Todo</url>
++  <url type="homepage">https://gitlab.gnome.org/World/Endeavour</url>
+   <url type="bugtracker">https://gitlab.gnome.org/World/Endeavour/issues</url>
++  <url type="vcs-browser">https://gitlab.gnome.org/World/Endeavour</url>
++  <url type="translate">https://l10n.gnome.org/module/Endeavour/</url>
+   <project_group>GNOME</project_group>
+ 
+   <screenshots>
+-    <screenshot width="1920" height="1080">
++    <screenshot width="1920" height="1080" type="default">
+       <image>https://gitlab.gnome.org/World/Endeavour/raw/main/data/appdata/no-tasks.png</image>
+       <caption>Empty state</caption>
+     </screenshot>
+@@ -37,7 +39,7 @@
+     <release date="2022-11-02" version="43.0">
+       <description>
+         <p>
+-          Endeavour 43 brings major improvements:
++          Endeavour 43 brings major improvements:</p>
+           <ul>
+             <li>
+               The Welcome screen has been removed, as its design didn't really
+@@ -54,7 +56,6 @@
+               Lots of bugs have been squashed, leading to a more stable experience.
+             </li>
+           </ul>
+-        </p>
+       </description>
+     </release>
+ 
+@@ -95,7 +96,7 @@
+           After 4 years in development, we are proud to annouce GNOME To Do 40.0!
+         </p>
+         <p>
+-          GNOME To Do 40 brings major improvements:
++          GNOME To Do 40 brings major improvements:</p>
+           <ul>
+             <li>
+               Loading, saving, and editing tasks is now completely asynchronous. This
+@@ -112,45 +113,16 @@
+               rewarding and engaging to use.
+             </li>
+           </ul>
+-        </p>
+         <p>
+           Unfortunately, Todoist and Todo.txt are disabled now. The future of these
+           integration points is uncertain, given that the featureset they support is
+           different than GNOME To Do.
+         </p>
+         <p>This release also updates translations, and adds new translations.</p>
+       </description>
+     </release>
+   </releases>
+-  <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++  <content_rating type="oars-1.1" />
+   <launchable type="desktop-id">org.gnome.Todo.desktop</launchable>
+   <developer_name>Jamie Murphy</developer_name>
+   <update_contact>hello@itsjamie.dev</update_contact>
+--
+libgit2 1.7.2
+

--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.Todo",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "endeavour",
   "finish-args": [
@@ -134,67 +134,6 @@
           "commit": "ed45e3272a88ea9097a4fe25b5d6bfed4e1272ce",
           "tag": "3.46.0",
           "url": "https://gitlab.gnome.org/GNOME/evolution-data-server.git"
-        }
-      ]
-    },
-    {
-      "name": "libadwaita",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dexamples=false",
-        "-Dtests=false",
-        "-Dvapi=false"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-          "tag": "1.2.alpha",
-          "commit": "9150f4016a04064a00733b78391c8e6aad49bee8"
-        }
-      ],
-      "modules": [
-        {
-          "name": "sassc",
-          "cleanup": [
-            "*"
-          ],
-          "sources": [
-            {
-              "type": "archive",
-              "url": "https://github.com/sass/sassc/archive/3.5.0.tar.gz",
-              "sha256": "26f54e31924b83dd706bc77df5f8f5553a84d51365f0e3c566df8de027918042"
-            },
-            {
-              "type": "script",
-              "dest-filename": "autogen.sh",
-              "commands": [
-                "autoreconf -si"
-              ]
-            }
-          ],
-          "modules": [
-            {
-              "name": "libsass",
-              "cleanup": [
-                "*"
-              ],
-              "sources": [
-                {
-                  "type": "archive",
-                  "url": "https://github.com/sass/libsass/archive/3.5.4.tar.gz",
-                  "sha256": "5f61cbcddaf8e6ef7a725fcfa5d05297becd7843960f245197ebb655ff868770"
-                },
-                {
-                  "type": "script",
-                  "dest-filename": "autogen.sh",
-                  "commands": [
-                    "autoreconf -si"
-                  ]
-                }
-              ]
-            }
-          ]
         }
       ]
     },

--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -41,8 +41,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.gnome.org/sources/gnome-online-accounts/3.46/gnome-online-accounts-3.46.0.tar.xz",
-          "sha256": "5e7859ce4858a6b99d3995ed70527d66e297bb90bbf75ec8780fe9da22c1fcaa"
+          "url": "https://download.gnome.org/sources/gnome-online-accounts/3.52/gnome-online-accounts-3.52.1.tar.xz",
+          "sha256": "37c7522ff9454f8371b5a8725bba76ed7430c95b1f9efc7feba6268f052d1eb7"
         }
       ]
     },
@@ -61,8 +61,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/libical/libical/releases/download/v3.0.14/libical-3.0.14.tar.gz",
-          "sha256": "4284b780356f1dc6a01f16083e7b836e63d3815e27ed0eaaad684712357ccc8f"
+          "url": "https://github.com/libical/libical/releases/download/v3.0.18/libical-3.0.18.tar.gz",
+          "sha256": "72b7dc1a5937533aee5a2baefc990983b66b141dd80d43b51f80aced4aae219c"
         }
       ]
     },
@@ -81,8 +81,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.gnome.org/sources/libpeas/1.34/libpeas-1.34.0.tar.xz",
-          "sha256": "4305f715dab4b5ad3e8007daec316625e7065a94e63e25ef55eb1efb964a7bf0"
+          "url": "https://download.gnome.org/sources/libpeas/1.36/libpeas-1.36.0.tar.xz",
+          "sha256": "297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c"
         }
       ]
     },
@@ -130,10 +130,9 @@
       "buildsystem": "cmake-ninja",
       "sources": [
         {
-          "type": "git",
-          "commit": "ed45e3272a88ea9097a4fe25b5d6bfed4e1272ce",
-          "tag": "3.46.0",
-          "url": "https://gitlab.gnome.org/GNOME/evolution-data-server.git"
+          "type": "archive",
+          "url": "https://download.gnome.org/sources/evolution-data-server/3.52/evolution-data-server-3.52.4.tar.xz",
+          "sha256": "1b36a839db1c8d898066e19be78b995930a0a2f2a886f149e4f64e1755f064f7"
         }
       ]
     },

--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -20,11 +20,13 @@
   "cleanup": [
     "/include",
     "/lib/pkgconfig",
-    "/share/pkgconfig",
-    "/share/aclocal",
+    "/libexec",
     "/man",
-    "/share/man",
+    "/share/aclocal",
+    "/share/gir-1.0",
     "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
     "/share/vala",
     "*.la",
     "*.a"

--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -146,6 +146,10 @@
           "url": "https://gitlab.gnome.org/World/Endeavour.git",
           "tag": "43.0",
           "commit": "92706b42784e553d9f841117111a5e14bd201e1c"
+        },
+        {
+          "type": "patch",
+          "path": "fix-appdata.patch"
         }
       ]
     }

--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.Todo",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "46",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "command": "endeavour",
   "finish-args": [


### PR DESCRIPTION
- Update Endeavour runtime to version 47, as runtime 45 reached EOL.
- Remove redundant sources provided by the runtime.
- Update related modules to comply with GNOME runtime requirements.

Fixes: https://github.com/flathub/org.gnome.Todo/issues/25