### PR TITLE
Update runtime to 49, update components, add x-checker-data

### DIFF
--- a/fix-url.patch
+++ b/fix-url.patch
@@ -7,12 +7,12 @@ index 12d0dd3..f4e96b6 100644
    <screenshots>
      <screenshot width="1920" height="1080" type="default">
 -      <image>https://gitlab.gnome.org/World/Endeavour/raw/main/data/appdata/no-tasks.png</image>
-+      <image>https://gitlab.gnome.org/World/Endeavour/-/blob/92706b42784e553d9f841117111a5e14bd201e1c/data/appdata/no-tasks.png</image>
++      <image>https://gitlab.gnome.org/World/Endeavour/-/raw/92706b42784e553d9f841117111a5e14bd201e1c/data/appdata/no-tasks.png</image>
        <caption>Empty state</caption>
      </screenshot>
      <screenshot width="1920" height="1080">
 -      <image>https://gitlab.gnome.org/World/Endeavour/raw/main/data/appdata/task-list.png</image>
-+      <image>https://gitlab.gnome.org/World/Endeavour/-/blob/92706b42784e553d9f841117111a5e14bd201e1c/data/appdata/task-list.png</image>
++      <image>https://gitlab.gnome.org/World/Endeavour/-/raw/92706b42784e553d9f841117111a5e14bd201e1c/data/appdata/task-list.png</image>
        <caption>Task lists</caption>
      </screenshot>
    </screenshots>

--- a/fix-url.patch
+++ b/fix-url.patch
@@ -1,0 +1,18 @@
+diff --git a/data/appdata/org.gnome.Todo.appdata.xml.in.in b/data/appdata/org.gnome.Todo.appdata.xml.in.in
+index 12d0dd3..f4e96b6 100644
+--- a/data/appdata/org.gnome.Todo.appdata.xml.in.in
++++ b/data/appdata/org.gnome.Todo.appdata.xml.in.in
+@@ -21,11 +21,11 @@
+ 
+   <screenshots>
+     <screenshot width="1920" height="1080" type="default">
+-      <image>https://gitlab.gnome.org/World/Endeavour/raw/main/data/appdata/no-tasks.png</image>
++      <image>https://gitlab.gnome.org/World/Endeavour/-/blob/92706b42784e553d9f841117111a5e14bd201e1c/data/appdata/no-tasks.png</image>
+       <caption>Empty state</caption>
+     </screenshot>
+     <screenshot width="1920" height="1080">
+-      <image>https://gitlab.gnome.org/World/Endeavour/raw/main/data/appdata/task-list.png</image>
++      <image>https://gitlab.gnome.org/World/Endeavour/-/blob/92706b42784e553d9f841117111a5e14bd201e1c/data/appdata/task-list.png</image>
+       <caption>Task lists</caption>
+     </screenshot>
+   </screenshots>

--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -1,158 +1,182 @@
 {
-  "app-id": "org.gnome.Todo",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
-  "sdk": "org.gnome.Sdk",
-  "command": "endeavour",
-  "finish-args": [
-    "--device=dri",
-    "--share=ipc",
-    "--socket=fallback-x11",
-    "--socket=wayland",
-    "--share=network",
-    "--system-talk-name=org.freedesktop.login1",
-    "--talk-name=org.gnome.evolution.dataserver.AddressBook9",
-    "--talk-name=org.gnome.evolution.dataserver.Calendar8",
-    "--talk-name=org.gnome.evolution.dataserver.Sources5",
-    "--talk-name=org.gnome.evolution.dataserver.Subprocess.Backend.*",
-    "--talk-name=org.gnome.OnlineAccounts"
-  ],
-  "cleanup": [
-    "/include",
-    "/lib/pkgconfig",
-    "/libexec",
-    "/man",
-    "/share/aclocal",
-    "/share/gir-1.0",
-    "/share/gtk-doc",
-    "/share/man",
-    "/share/pkgconfig",
-    "/share/vala",
-    "*.la",
-    "*.a"
-  ],
-  "modules": [
-    "shared-modules/intltool/intltool-0.51.json",
-    {
-      "name": "gnome-online-accounts",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dvapi=false",
-        "-Dgoabackend=false"
-      ],
-      "sources": [
+    "app-id": "org.gnome.Todo",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "48",
+    "sdk": "org.gnome.Sdk",
+    "command": "endeavour",
+    "finish-args": [
+        "--device=dri",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--share=network",
+        "--system-talk-name=org.freedesktop.login1",
+        "--talk-name=org.gnome.evolution.dataserver.AddressBook9",
+        "--talk-name=org.gnome.evolution.dataserver.Calendar8",
+        "--talk-name=org.gnome.evolution.dataserver.Sources5",
+        "--talk-name=org.gnome.evolution.dataserver.Subprocess.Backend.*",
+        "--talk-name=org.gnome.OnlineAccounts"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/libexec",
+        "/man",
+        "/share/aclocal",
+        "/share/gir-1.0",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        "shared-modules/intltool/intltool-0.51.json",
         {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/gnome-online-accounts/3.52/gnome-online-accounts-3.52.1.tar.xz",
-          "sha256": "37c7522ff9454f8371b5a8725bba76ed7430c95b1f9efc7feba6268f052d1eb7"
-        }
-      ]
-    },
-    {
-      "name": "libical",
-      "cleanup": [
-        "/lib/cmake"
-      ],
-      "buildsystem": "cmake-ninja",
-      "config-opts": [
-        "-DCMAKE_INSTALL_LIBDIR:PATH=/app/lib",
-        "-DBUILD_SHARED_LIBS=On",
-        "-DICAL_BUILD_DOCS=False",
-        "-DWITH_CXX_BINDINGS=False"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/libical/libical/releases/download/v3.0.18/libical-3.0.18.tar.gz",
-          "sha256": "72b7dc1a5937533aee5a2baefc990983b66b141dd80d43b51f80aced4aae219c"
-        }
-      ]
-    },
-    {
-      "name": "libpeas",
-      "buildsystem": "meson",
-      "cleanup": [
-        "/bin/*",
-        "/lib/peas-demo",
-        "/lib/libpeas-gtk*"
-      ],
-      "config-opts": [
-        "-Dwidgetry=false",
-        "-Ddemos=false"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/libpeas/1.36/libpeas-1.36.0.tar.xz",
-          "sha256": "297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c"
-        }
-      ]
-    },
-    {
-      "name": "rest",
-      "config-opts": [
-        "-Dintrospection=false",
-        "-Dgtk_doc=false"
-      ],
-      "buildsystem": "meson",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/rest/0.9/rest-0.9.1.tar.xz",
-          "sha256": "9266a5c10ece383e193dfb7ffb07b509cc1f51521ab8dad76af96ed14212c2e3"
-        }
-      ]
-    },
-    {
-      "name": "evolution-data-server",
-      "cleanup": [
-        "/share/GConf"
-      ],
-      "config-opts": [
-        "-DENABLE_CANBERRA=OFF",
-        "-DENABLE_DOT_LOCKING=OFF",
-        "-DENABLE_FILE_LOCKING=fcntl",
-        "-DENABLE_GTK=OFF",
-        "-DENABLE_GOOGLE=OFF",
-        "-DENABLE_VALA_BINDINGS=ON",
-        "-DENABLE_WEATHER=OFF",
-        "-DWITH_OPENLDAP=OFF",
-        "-DWITH_LIBDB=OFF",
-        "-DENABLE_INTROSPECTION=ON",
-        "-DENABLE_INSTALLED_TESTS=OFF",
-        "-DENABLE_GTK_DOC=OFF",
-        "-DENABLE_EXAMPLES=OFF",
-        "-DENABLE_VALA_BINDINGS=OFF",
-        "-DENABLE_INTROSPECTION=OFF",
-        "-DWITH_PHONENUMBER=OFF",
-        "-DWITH_SYSTEMDUSERUNITDIR=OFF",
-        "-DENABLE_OAUTH2=OFF",
-        "-DENABLE_OAUTH2_WEBKITGTK4=OFF"
-      ],
-      "buildsystem": "cmake-ninja",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/evolution-data-server/3.52/evolution-data-server-3.52.4.tar.xz",
-          "sha256": "1b36a839db1c8d898066e19be78b995930a0a2f2a886f149e4f64e1755f064f7"
-        }
-      ]
-    },
-    {
-      "name": "endeavour",
-      "buildsystem": "meson",
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/World/Endeavour.git",
-          "tag": "43.0",
-          "commit": "92706b42784e553d9f841117111a5e14bd201e1c"
+            "name": "gnome-online-accounts",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dvapi=false",
+                "-Dgoabackend=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-online-accounts/3.55/gnome-online-accounts-3.55.1.tar.xz",
+                    "sha256": "a0b50fb75553c1e360713a827321cd17e2f91a735b8205ba5fd0ff374b26108b",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gnome-online-accounts"
+                    }
+                }
+            ]
         },
         {
-          "type": "patch",
-          "path": "fix-appdata.patch"
+            "name": "libical",
+            "cleanup": [
+                "/lib/cmake"
+            ],
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_INSTALL_LIBDIR:PATH=/app/lib",
+                "-DBUILD_SHARED_LIBS=On",
+                "-DICAL_BUILD_DOCS=False",
+                "-DWITH_CXX_BINDINGS=False"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libical/libical/releases/download/v3.0.20/libical-3.0.20.tar.gz",
+                    "sha256": "e73de92f5a6ce84c1b00306446b290a2b08cdf0a80988eca0a2c9d5c3510b4c2",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1637,
+                        "url-template": "https://github.com/libical/libical/releases/download/v$version/libical-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libpeas",
+            "buildsystem": "meson",
+            "cleanup": [
+                "/bin/*",
+                "/lib/peas-demo",
+                "/lib/libpeas-gtk*"
+            ],
+            "config-opts": [
+                "-Dwidgetry=false",
+                "-Ddemos=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libpeas/1.36/libpeas-1.36.0.tar.xz",
+                    "sha256": "297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "libpeas",
+                        "versions": {
+                            "<": "1.99"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "rest",
+            "config-opts": [
+                "-Dintrospection=false",
+                "-Dgtk_doc=false"
+            ],
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/rest/0.9/rest-0.9.1.tar.xz",
+                    "sha256": "9266a5c10ece383e193dfb7ffb07b509cc1f51521ab8dad76af96ed14212c2e3",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "rest"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "evolution-data-server",
+            "cleanup": [
+                "/share/GConf"
+            ],
+            "config-opts": [
+                "-DENABLE_CANBERRA=OFF",
+                "-DENABLE_DOT_LOCKING=OFF",
+                "-DENABLE_FILE_LOCKING=fcntl",
+                "-DENABLE_GTK=OFF",
+                "-DENABLE_GOOGLE=OFF",
+                "-DENABLE_VALA_BINDINGS=ON",
+                "-DENABLE_WEATHER=OFF",
+                "-DWITH_OPENLDAP=OFF",
+                "-DWITH_LIBDB=OFF",
+                "-DENABLE_INTROSPECTION=ON",
+                "-DENABLE_INSTALLED_TESTS=OFF",
+                "-DENABLE_GTK_DOC=OFF",
+                "-DENABLE_EXAMPLES=OFF",
+                "-DENABLE_VALA_BINDINGS=OFF",
+                "-DENABLE_INTROSPECTION=OFF",
+                "-DWITH_PHONENUMBER=OFF",
+                "-DWITH_SYSTEMDUSERUNITDIR=OFF",
+                "-DENABLE_OAUTH2=OFF",
+                "-DENABLE_OAUTH2_WEBKITGTK4=OFF"
+            ],
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/evolution-data-server/3.57/evolution-data-server-3.57.2.tar.xz",
+                    "sha256": "9b2647c4265e0a6767fe19c7d602eb9bdcf3f428e4f9c41617e962a7fff9eebd",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "evolution-data-server"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "endeavour",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/World/Endeavour.git",
+                    "tag": "43.0",
+                    "commit": "92706b42784e553d9f841117111a5e14bd201e1c"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix-appdata.patch"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -174,7 +174,10 @@
                 },
                 {
                     "type": "patch",
-                    "path": "fix-appdata.patch"
+                    "paths": [
+                        "fix-appdata.patch",
+                        "fix-url.patch"
+                    ]
                 }
             ]
         }

--- a/org.gnome.Todo.json
+++ b/org.gnome.Todo.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Todo",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "endeavour",
     "finish-args": [
@@ -43,8 +43,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-online-accounts/3.55/gnome-online-accounts-3.55.1.tar.xz",
-                    "sha256": "a0b50fb75553c1e360713a827321cd17e2f91a735b8205ba5fd0ff374b26108b",
+                    "url": "https://download.gnome.org/sources/gnome-online-accounts/3.56/gnome-online-accounts-3.56.2.tar.xz",
+                    "sha256": "ce88df65457f0e63a0d8daff13322e29ecb584197a187f48a3a21be2fcd1c824",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "gnome-online-accounts"
@@ -153,8 +153,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/evolution-data-server/3.57/evolution-data-server-3.57.2.tar.xz",
-                    "sha256": "9b2647c4265e0a6767fe19c7d602eb9bdcf3f428e4f9c41617e962a7fff9eebd",
+                    "url": "https://download.gnome.org/sources/evolution-data-server/3.58/evolution-data-server-3.58.2.tar.xz",
+                    "sha256": "6942ecfc39ebb36b0b4363adff00771c1c2dfa34f54e80ec92c3baa3feb020fb",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "evolution-data-server"


### PR DESCRIPTION
I apologize for the hard-to-read diff, running flatpak-external-data-checker locally changed the indentation to 4 spaces.